### PR TITLE
add sinonJS to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "mocha": "^3.0.0",
     "mocha-multi": "^0.9.0",
     "node-inspector": "^0.12.8",
-    "react-addons-test-utils": "^15.3.0"
+    "react-addons-test-utils": "^15.3.0",
+    "sinon": "^1.17.6"
   },
   "dependencies": {
     "react": "^15.3.0",


### PR DESCRIPTION
missing the devDependency for `sinonJS` that is needed for the test suite to run. @PeterBell @aturkewi @AnnJohn 