### PR TITLE
change order of LoginForm specs so they work

### DIFF
--- a/test/LoginForm-test.js
+++ b/test/LoginForm-test.js
@@ -51,22 +51,6 @@ describe("<LoginForm />", () => {
       ).to.be.true;
     });
 
-    it("should call the `onSubmit` callback prop when the form is being submitted", () => {
-      const wrapper = shallow(<LoginForm onSubmit={spy} />);
-      wrapper.find("#test-username").simulate("change", {
-        target: { name: "username", id: "test-username", value: "johndoe" },
-      });
-      wrapper.find("#test-password").simulate("change", {
-        target: {
-          name: "password",
-          id: "test-password",
-          value: "supersecret",
-        },
-      });
-      wrapper.find("form").simulate("submit", { preventDefault: spy });
-      expect(spy.called, "The `onSubmit` prop is not being called").to.be.true;
-    });
-
     it("should not call the `onSubmit` callback prop when the username and/or password fields are empty", () => {
       const wrapper = shallow(<LoginForm onSubmit={spy} />);
 
@@ -97,6 +81,22 @@ describe("<LoginForm />", () => {
         spy.called,
         "The `onSubmit` prop is being called with one or more empty form fields"
       ).to.be.false;
+    });
+    
+    it("should call the `onSubmit` callback prop when the form is being submitted", () => {
+      const wrapper = shallow(<LoginForm onSubmit={spy} />);
+      wrapper.find("#test-username").simulate("change", {
+        target: { name: "username", id: "test-username", value: "johndoe" },
+      });
+      wrapper.find("#test-password").simulate("change", {
+        target: {
+          name: "password",
+          id: "test-password",
+          value: "supersecret",
+        },
+      });
+      wrapper.find("form").simulate("submit", { preventDefault: spy });
+      expect(spy.called, "The `onSubmit` prop is not being called").to.be.true;
     });
   });
 });


### PR DESCRIPTION
@curiositypaths 

Had an issue with a student where we couldn't solve these specs in order because the first spec doesn't pass, I think switching those worked because the first test requires that event.preventDefault get called, but isn't passing a spy for the onSubmit prop, so if you call this.props.onSubmit when the username and password are blank, then you'll start failing the first test when you pass the second one.
Switching the order of the 2nd and 3rd tests should allow doing them in order.